### PR TITLE
Completely drop PHP 7.1 version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
 		"seo", 
 		"search engine optimization", 
 		"php7",
-		"php7.1",
 		"schema.org",
 		"sitemaps", 
 		"sitemap.xml", 
@@ -25,7 +24,7 @@
 		}
 	],
 	"require":  {
-		"php": ">=7.1",
+		"php": ">=7.2",
 		"ext-xml": "*",
 		"ext-curl": "*"
 	},


### PR DESCRIPTION
Since this package drops some stuffs about `php-7.1` version support, I think `composer.json` file should be done for this.